### PR TITLE
[backend] Add filters for ads

### DIFF
--- a/BackendApp/BackendApp/settings.py
+++ b/BackendApp/BackendApp/settings.py
@@ -40,12 +40,12 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework_simplejwt",
     "drf_spectacular",
-    'django_filters',
+    "django_filters",
     "userAuth",
     "permissionHandler",
     "shelterRelated",
     "adRelated",
-    "photoAlbum"
+    "photoAlbum",
 ]
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.AllowAny",),
@@ -53,7 +53,7 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
-    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
+    "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
 }
 SPECTACULAR_SETTINGS = {
     "TITLE": "MeowdoptMeApp API",

--- a/BackendApp/BackendApp/settings.py
+++ b/BackendApp/BackendApp/settings.py
@@ -154,3 +154,6 @@ AUTH_PROFILE_MODULE = "userAuth.User"
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
+
+# for converts the '+' back to a space in filter url
+APPEND_SLASH = True

--- a/BackendApp/BackendApp/settings.py
+++ b/BackendApp/BackendApp/settings.py
@@ -39,12 +39,13 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "rest_framework_simplejwt",
+    "drf_spectacular",
+    'django_filters',
     "userAuth",
     "permissionHandler",
     "shelterRelated",
     "adRelated",
-    "photoAlbum",
-    "drf_spectacular",
+    "photoAlbum"
 ]
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.AllowAny",),
@@ -52,6 +53,7 @@ REST_FRAMEWORK = {
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
 }
 SPECTACULAR_SETTINGS = {
     "TITLE": "MeowdoptMeApp API",

--- a/BackendApp/BackendApp/settings.py
+++ b/BackendApp/BackendApp/settings.py
@@ -47,7 +47,6 @@ INSTALLED_APPS = [
     "adRelated",
     "photoAlbum",
     "userManage",
-    "drf_spectacular",
 ]
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.AllowAny",),

--- a/BackendApp/adRelated/filters.py
+++ b/BackendApp/adRelated/filters.py
@@ -1,12 +1,16 @@
 from django_filters import FilterSet, CharFilter
 
-from .models import Ad
+from .models import Ad, PetCharacteristics, Pet
 
 
 class AdFilter(FilterSet):
-    pet = CharFilter(field_name="pet")
+    species = CharFilter(field_name="pet__pet_characteristics__species")
+    breed = CharFilter(field_name="pet__pet_characteristics__breed")
+    gender = CharFilter(field_name="pet__pet_characteristics__gender")
+    year = CharFilter(field_name="pet__pet_characteristics__date_of_birth__year")
+    month = CharFilter(field_name="pet__pet_characteristics__date_of_birth__month")
+    color = CharFilter(field_name="pet__pet_characteristics__color")
 
     class Meta:
         model = Ad
-        fields = ["pet"]
-
+        fields = ["active", "pet", "shelter"]

--- a/BackendApp/adRelated/filters.py
+++ b/BackendApp/adRelated/filters.py
@@ -1,0 +1,12 @@
+from django_filters import FilterSet, CharFilter
+
+from .models import Ad
+
+
+class AdFilter(FilterSet):
+    pet = CharFilter(field_name="pet")
+
+    class Meta:
+        model = Ad
+        fields = ["pet"]
+

--- a/BackendApp/adRelated/tests.py
+++ b/BackendApp/adRelated/tests.py
@@ -193,7 +193,7 @@ class AdFiltersTests(APITestCase):
         )
 
     def test_queryset_exist(self):
-        url = f"{self.url}?species=dog&breed=mixed breed&gender=female&year=2019&month=5&color=white"
+        url = f"{self.url}?species=dog&breed=mixed+breed&gender=female&year=2019&month=5&color=white"
         response = self.client.get(url)
         self.assertEqual(
             response.status_code,
@@ -203,7 +203,7 @@ class AdFiltersTests(APITestCase):
         self.assertEqual(response.data[0]["shelter"], 1)
 
     def test_queryset_not_exist(self):
-        url = f"{self.url}?species=dog&breed=mixed breed&gender=female&year=2021&month=2&color=white"
+        url = f"{self.url}?species=dog&breed=mixed+breed&gender=female&year=2021&month=2&color=white"
         response = self.client.get(url)
         self.assertEqual(
             response.status_code,

--- a/BackendApp/adRelated/tests.py
+++ b/BackendApp/adRelated/tests.py
@@ -167,3 +167,47 @@ class PetTests(APITestCase):
             status.HTTP_200_OK,
             f"Expected Response Code 200, received {response.status_code} instead.",
         )
+
+
+class AdFiltersTests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = reverse("ad_list")
+        date_of_birth = DateOfBirth.objects.create(year=2019, month=5)
+        pet_char = PetCharacteristics.objects.create(
+            species="dog",
+            breed="mixed breed",
+            gender="female",
+            color="white",
+            date_of_birth=date_of_birth,
+        )
+        Pet.objects.create(name="Jarzyna", pet_characteristics=pet_char)
+        shelter = Shelter.objects.create()
+        PhotoAlbum.objects.create()
+        Ad.objects.create(
+            active=True,
+            shelter=shelter,
+            description="Jarzyna to pies, który trafił do nas wychudzony i schorowany, jednak dzięki właściwej opiece, stanęła na nogi. Jest wulkanem energii, świetnie chodzi na smyczy, uwielbia kontakt z ludźmi. Najlepiej odnajdzie się w domu z ogrodem.",
+            pet_id=1,
+            photo_album_id=1,
+        )
+
+    def test_queryset_exist(self):
+        url = f"{self.url}?species=dog&breed=mixed breed&gender=female&year=2019&month=5&color=white"
+        response = self.client.get(url)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            f"Expected Response Code 200, received {response.status_code} instead.",
+        )
+        self.assertEqual(response.data[0]["shelter"], 1)
+
+    def test_queryset_not_exist(self):
+        url = f"{self.url}?species=dog&breed=mixed breed&gender=female&year=2021&month=2&color=white"
+        response = self.client.get(url)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            f"Expected Response Code 200, received {response.status_code} instead.",
+        )
+        self.assertRaises(IndexError, response.data[0], "shelter")

--- a/BackendApp/adRelated/tests.py
+++ b/BackendApp/adRelated/tests.py
@@ -210,4 +210,5 @@ class AdFiltersTests(APITestCase):
             status.HTTP_200_OK,
             f"Expected Response Code 200, received {response.status_code} instead.",
         )
-        self.assertRaises(IndexError, response.data[0], "shelter")
+        with self.assertRaises(IndexError):
+            result = response.data[0]["shelter"]

--- a/BackendApp/adRelated/views.py
+++ b/BackendApp/adRelated/views.py
@@ -5,16 +5,21 @@ from rest_framework.generics import (
     RetrieveUpdateDestroyAPIView,
 )
 from rest_framework.response import Response
+from django_filters.rest_framework import DjangoFilterBackend
 
+from .filters import AdFilter
 from .models import Pet, Ad
 from .permissions import AdRelatedPermission
 from .serializers import PetSerializer, AdSerializer
+
 
 
 class AdList(ListAPIView):
     queryset = Ad.objects.all()
     serializer_class = AdSerializer
     lookup_field = "pk"
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = AdFilter
 
 
 class AdCreate(CreateAPIView):

--- a/BackendApp/adRelated/views.py
+++ b/BackendApp/adRelated/views.py
@@ -13,7 +13,6 @@ from .permissions import AdRelatedPermission
 from .serializers import PetSerializer, AdSerializer
 
 
-
 class AdList(ListAPIView):
     queryset = Ad.objects.all()
     serializer_class = AdSerializer

--- a/BackendApp/requirements.txt
+++ b/BackendApp/requirements.txt
@@ -9,6 +9,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 dill==0.3.6
 Django==4.2
+django-filter==23.2
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
 drf-spectacular==0.26.2


### PR DESCRIPTION
Making filters for displaying specific ads through django-filters lib 
Sample address for filtering: ```http://127.0.0.1:8000/ads/?species=dog&breed=mixed+breed&gender=female&year=2021&month=2&color=white```

:rocket:
